### PR TITLE
fix: wrong rank for TACO

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -105,7 +105,7 @@ disableKinds=["404", "RSS", "sitemap"]
         abbr = "TACO"
         fullname = "ACM Transactions on Architecture and Code Optimization"
         publisher = "ACM"
-        rank = "B"
+        rank = "A"
         type = "期刊"
         field = "计算机体系结构/并行与分布计算/存储系统"
 


### PR DESCRIPTION
ACM Transactions on Architecture and Code Optimization杂志应是一个A类学术期刊。
![image](https://github.com/user-attachments/assets/bdb88fe9-98e7-48b7-89df-87f2ee887356)
